### PR TITLE
Fix website building for forked repos

### DIFF
--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -51,16 +51,14 @@ jobs:
             -printf "%f\n" \
           | xargs -I% \
             cp $SOURCE_DIR/% $WEBSITE_DIR/placeholder_%
+          # update specifications source base url with current repo and branch
+          echo "github_specs_base_url: \"https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/specifications\"" \
+            >> ${{ github.workspace }}/main-branch/website/_config.yml
 
       - name: Build static website
         run: |
           cd ${{ github.workspace }}/main-branch/website
           bundle exec jekyll build -d ${{ github.workspace }}/gh-pages-branch
-
-      - name: Maintainer domain
-        if: ${{ github.repository == 'daniel-utilityapi/Customer-Data' }}
-        run: |
-          echo -n "cdsc-wg1-maintainer-branch.utilityapi.com" > ${{ github.workspace }}/gh-pages-branch/CNAME
 
       - name: Production domain
         if: ${{ github.repository == 'carbon-data-specification/Customer-Data' }}

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -35,6 +35,7 @@ jobs:
           # set source and website directories
           export WEBSITE_DIR="${{ github.workspace }}/main-branch/website/_includes/spec_copies"
           export SOURCE_DIR="${{ github.workspace }}/main-branch/specifications"
+          
           # remove any existing placeholder files
           find \
             $WEBSITE_DIR \
@@ -42,6 +43,7 @@ jobs:
             -path "$WEBSITE_DIR/placeholder_*.md" \
           | xargs -I% \
             rm %
+          
           # copy original files to website directory
           find \
             $SOURCE_DIR \
@@ -51,16 +53,28 @@ jobs:
             -printf "%f\n" \
           | xargs -I% \
             cp $SOURCE_DIR/% $WEBSITE_DIR/placeholder_%
+          
           # update specifications source base url with current repo and branch
           echo "github_specs_base_url: \"https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/specifications\"" \
             >> ${{ github.workspace }}/main-branch/website/_config.yml
+          
+          # default base url is root of domain
+          echo "baseurl: /" \
+            >> ${{ github.workspace }}/main-branch/website/_config.yml
+
+      - name: Non-production builds use Github Page's default base url (/Customer-Data/)
+        if: ${{ github.repository != 'carbon-data-specification/Customer-Data' }}
+        run: |
+          sed -i \
+            's|baseurl: \/|baseurl: /Customer-Data/|g' \
+            ${{ github.workspace }}/main-branch/website/_config.yml
 
       - name: Build static website
         run: |
           cd ${{ github.workspace }}/main-branch/website
           bundle exec jekyll build -d ${{ github.workspace }}/gh-pages-branch
 
-      - name: Production domain
+      - name: Set production domain
         if: ${{ github.repository == 'carbon-data-specification/Customer-Data' }}
         run: |
           echo -n "customerdata.carbondataspec.org" > ${{ github.workspace }}/gh-pages-branch/CNAME

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -3,3 +3,6 @@ exclude:
   - Gemfile.lock
   - README.md
   - CNAME
+
+# base url for specification source links (added during website build)
+#github_specs_base_url: "https://github.com/carbon-data-specification/Customer-Data/blob/main/specifications"

--- a/website/_includes/spec_list.md
+++ b/website/_includes/spec_list.md
@@ -1,0 +1,2 @@
+* `CDSC-WG1-01` - Server Metadata [[Overview]({{ "/specs/cdsc-wg1-01/overview" | relative_url }})] [[Specification]({{ "/specs/cdsc-wg1-01" | relative_url }})] `(in progress)`
+* `CDSC-WG1-*` - Additional specifications will be added in the future

--- a/website/_layouts/base.html
+++ b/website/_layouts/base.html
@@ -194,7 +194,7 @@
                                     </li>
                                     <li>
                                         <a href="https://lists.lfenergy.org/g/cdsc-strategy-committee" target="_blank"
-                                            >Strategy Committee (TSC)
+                                            >Strategy Committee (SC)
                                             <svg class="svgicon"><use href="#fa-external-link"/></svg></a>
                                     </li>
                                 </ul>

--- a/website/index.md
+++ b/website/index.md
@@ -20,23 +20,22 @@ in order to facilitate carbon emissions calculations and decarbonization efforts
 
 ## Use Cases
 
-We have defined several broad categories of [use cases](./use-cases) we will focus on addressing,
+We have defined several broad categories of [use cases]({{ "/use-cases" | relative_url }}) we will focus on addressing,
 along with what customer data types and functionalities will need to be specified to accommodate
 those use cases.
 
-* `Use Case 1` - [Carbon Accounting](./use-cases#use-case-carbon-accounting)
-* `Use Case 2` - [Decarbonization Projects](./use-cases#use-case-decarbonization-projects)
-* `Use Case 3` - [Distributed Grid Flexibility](./use-cases#use-case-distributed-flexibility)
-* `Use Case 4` - [Building Benchmarking](./use-cases#use-case-benchmarking)
+* `Use Case 1` - [Carbon Accounting]({{ "/use-cases" | relative_url }}#use-case-carbon-accounting)
+* `Use Case 2` - [Decarbonization Projects]({{ "/use-cases" | relative_url }}#use-case-decarbonization-projects)
+* `Use Case 3` - [Distributed Grid Flexibility]({{ "/use-cases" | relative_url }}#use-case-distributed-flexibility)
+* `Use Case 4` - [Building Benchmarking]({{ "/use-cases" | relative_url }}#use-case-benchmarking)
 
-We've also made a list of what data and functionality is specifically [not in scope](./use-cases#not-in-scope).
+We've also made a list of what data and functionality is specifically [not in scope]({{ "/use-cases" | relative_url }}#not-in-scope).
 
 ## Specifications
 
-These are the official [specifications](./specs) written by this working group.
+These are the official [specifications]({{ "/specs" | relative_url }}) written by this working group.
 
-* `CDSC-WG1-01` - Server Metadata [[Overview](./specs/cdsc-wg1-01/overview)] [[Specification](./specs/cdsc-wg1-01)] `(in progress)`
-* `CDSC-WG1-*` - Additional specifications will be added in the future
+{% include spec_list.md %}
 
 ## Get Involved
 

--- a/website/specs/cdsc-wg1-01/index.md
+++ b/website/specs/cdsc-wg1-01/index.md
@@ -10,7 +10,7 @@ meta_description: Linux Foundation Energy - Carbon Data Specification Consortium
 
 Looking for a more human-readable summary of this specification? Check out our [overview]({{ "/specs/cdsc-wg1-01/overview" | relative_url }}).
 
-Below is a rendering of the original specification [source]({{ site.github_specs_base_url }}/cdsc-wg1-01.md).
+Below is a rendering of the original specification source: [{{ site.github_specs_base_url }}/cdsc-wg1-01.md]({{ site.github_specs_base_url }}/cdsc-wg1-01.md)
 
 ---
 

--- a/website/specs/cdsc-wg1-01/index.md
+++ b/website/specs/cdsc-wg1-01/index.md
@@ -4,13 +4,13 @@ nav: specs
 title: CDSC-WG1 - 01 Server Metadata - Specification
 meta_description: Linux Foundation Energy - Carbon Data Specification Consortium (CDSC) - Customer DataWorking Group (WG1) - Specifications - cdsc-wg1-01 - Server Metadata
 ---
-[Home](../../) / [Specifications](../specs) / `cdsc-wg1-01` - Server Metadata
+[Home]({{ "/" | relative_url }}) / [Specifications]({{ "/specs" | relative_url }}) / `cdsc-wg1-01` - Server Metadata
 
 # Server Metadata
 
-Looking for a more human-readable summary of this specification? Check out our [overview](./overview).
+Looking for a more human-readable summary of this specification? Check out our [overview]({{ "/specs/cdsc-wg1-01/overview" | relative_url }}).
 
-Below is a rendering of the original specification [source](https://github.com/carbon-data-specification/Customer-Data/blob/main/specifications/cdsc-wg1-01.md).
+Below is a rendering of the original specification [source]({{ site.github_specs_base_url }}/cdsc-wg1-01.md).
 
 ---
 

--- a/website/specs/cdsc-wg1-01/overview.md
+++ b/website/specs/cdsc-wg1-01/overview.md
@@ -4,7 +4,7 @@ nav: specs
 title: CDSC-WG1 - 01 Server Metadata - Overview
 meta_description: Linux Foundation Energy - Carbon Data Specification Consortium (CDSC) - Customer DataWorking Group (WG1) - Specifications - cdsc-wg1-01 - Server Metadata - Overview
 ---
-[Home](../../../) / [Specifications](../../specs) / [`cdsc-wg1-01` - Server Metadata](../cdsc-wg1-01) / Overview
+[Home]({{ "/" | relative_url }}) / [Specifications]({{ "/specs" | relative_url }}) / [`cdsc-wg1-01` - Server Metadata]({{ "/specs/cdsc-wg1-01" | relative_url }}) / Overview
 
 # Server Metadata - Overview
 

--- a/website/specs/index.md
+++ b/website/specs/index.md
@@ -4,11 +4,10 @@ nav: specs
 title: CDSC-WG1 - Specifications
 meta_description: Linux Foundation Energy - Carbon Data Specification Consortium (CDSC) - Customer DataWorking Group (WG1) - List of Specifications
 ---
-[Home](../) / Specifications
+[Home]({{ "/" | relative_url }}) / Specifications
 
 # Specifications
 
 Below are the list of specifications this working group maintains.
 
-* `CDSC-WG1-01` - Server Metadata [[Overview](./cdsc-wg1-01/overview)] [[Specification](./cdsc-wg1-01)] `(in progress)`
-* `CDSC-WG1-*` - Additional specifications will be added in the future
+{% include spec_list.md %}

--- a/website/use-cases.md
+++ b/website/use-cases.md
@@ -4,7 +4,7 @@ nav: use_cases
 title: Use Cases
 meta_description: What are the use cases that the Customer Data specifications this working group is trying to address?
 ---
-[Home](../) / Use Cases
+[Home]({{ "/" | relative_url }}) / Use Cases
 
 # Use Cases
 


### PR DESCRIPTION
> By making a contribution to this repository, I agree to the terms indicated on [this repository](../1_Contributor-License-Agreement.md)

These changes streamline users' ability to fork and build their own versions of the website both locally (via `jekyll serve`) and on their own Github Pages workflows.

For example, see: https://daniel-utilityapi.github.io/Customer-Data/
